### PR TITLE
LRWebSocketConnection should listen for any socket errors

### DIFF
--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -22,6 +22,10 @@ class LRWebSocketConnection extends EventEmitter
       debug "LRWebSocketConnection(#{@id}) received #{data}"
       @parser.received(data)
 
+    @socket.on 'error', (err) =>
+      debug "LRWebSocketConnection(#{@id}) got an error #{err}"
+      @emit 'error', err
+
     @socket.on 'close', =>
       (clearTimeout @_handshakeTimeout; @_handshakeTimeout = null) if @_handshakeTimeout
       @emit 'disconnected'


### PR DESCRIPTION
# Background

`LRWebSocketConnection` should listen for any socket errors, otherwise, when the underlying socket emit `error` event due to TCP error, it will quit the host process.
## Sample scenario

The code below will crash `livereload-server` instantly

```
!function (WebSocket) {
    var ws = new WebSocket('ws://localhost:35729/livereload');

    ws.on('open', function () {
        process.exit(0);
    });
}(require('ws'));
```

It will crash with the following error.

```
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: read ECONNRESET
    at exports._errnoException (util.js:746:11)
    at TCP.onread (net.js:559:26)
```
